### PR TITLE
CI

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,0 +1,13 @@
+FROM pandoc/ubuntu:2.10.1
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --assume-yes \
+      wkhtmltopdf=0.12.5* \
+      fonts-noto && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY entrypoint.sh /
+
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.docker/entrypoint.sh
+++ b/.docker/entrypoint.sh
@@ -1,0 +1,5 @@
+#! /bin/sh
+set -e
+
+pandoc OSDManual.md --output OSDManual.html --css style.css --metadata title="Open Sound Data Manual" --standalone
+wkhtmltopdf OSDManual.html OSDManual.pdf

--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -1,0 +1,7 @@
+name: osdmanual
+
+description: build an OSD manual
+
+runs:
+  using: docker
+  image: ../../../.docker/Dockerfile

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,16 @@
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/build
+      - uses: actions/upload-artifact@v2
+        with:
+          name: OSDManual.html
+          path: OSDManual.html
+      - uses: actions/upload-artifact@v2
+        with:
+          name: OSDManual.pdf
+          path: OSDManual.pdf


### PR DESCRIPTION
CI するようにしました。

GitHub リポジトリーに push するだけで自動的に PDF が生成されます。

VS Code の [Markdown PDF 拡張機能](https://marketplace.visualstudio.com/items?itemName=yzane.markdown-pdf)とデフォルトスタイルが違うのでやたら文字が小さいですが、_style.css_ の編集でスタイルの変更ができます。CSS などのデバッグ用に途中成果物の HTML も出力するようにしています。

ここで成果物が確認できます。
https://github.com/kakkun61/osdmanual/actions/runs/308407531